### PR TITLE
Make ioredis a dependency, rather than a

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-websockets",
   "description": "Websocket system for Psychic applications",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "RVO Health",
   "repository": {
     "type": "git",
@@ -42,7 +42,6 @@
     "@rvoh/psychic": "*",
     "@socket.io/redis-adapter": "*",
     "@socket.io/redis-emitter": "*",
-    "ioredis": "*",
     "socket.io": "*",
     "socket.io-adapter": "*"
   },
@@ -61,7 +60,6 @@
     "bullmq": "^5.12.12",
     "eslint": "^9.9.1",
     "express": "^4.21.2",
-    "ioredis": "^5.4.1",
     "kysely": "^0.27.5",
     "kysely-codegen": "^0.17.0",
     "luxon-jest-matchers": "^0.1.14",
@@ -81,6 +79,7 @@
   },
   "packageManager": "yarn@4.7.0",
   "dependencies": {
+    "ioredis": "^5.6.1",
     "yoctocolors": "^2.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,7 +867,7 @@ __metadata:
     bullmq: "npm:^5.12.12"
     eslint: "npm:^9.9.1"
     express: "npm:^4.21.2"
-    ioredis: "npm:^5.4.1"
+    ioredis: "npm:^5.6.1"
     kysely: "npm:^0.27.5"
     kysely-codegen: "npm:^0.17.0"
     luxon-jest-matchers: "npm:^0.1.14"
@@ -890,7 +890,6 @@ __metadata:
     "@rvoh/psychic": "*"
     "@socket.io/redis-adapter": "*"
     "@socket.io/redis-emitter": "*"
-    ioredis: "*"
     socket.io: "*"
     socket.io-adapter: "*"
   languageName: unknown
@@ -3580,6 +3579,23 @@ __metadata:
     redis-parser: "npm:^3.0.0"
     standard-as-callback: "npm:^2.1.0"
   checksum: 10c0/e59d2cceb43ed74b487d7b50fa91b93246e734e5d4835c7e62f64e44da072f12ab43b044248012e6f8b76c61a7c091a2388caad50e8ad69a8ce5515a730b23b8
+  languageName: node
+  linkType: hard
+
+"ioredis@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "ioredis@npm:5.6.1"
+  dependencies:
+    "@ioredis/commands": "npm:^1.1.1"
+    cluster-key-slot: "npm:^1.1.0"
+    debug: "npm:^4.3.4"
+    denque: "npm:^2.1.0"
+    lodash.defaults: "npm:^4.2.0"
+    lodash.isarguments: "npm:^3.1.0"
+    redis-errors: "npm:^1.2.0"
+    redis-parser: "npm:^3.0.0"
+    standard-as-callback: "npm:^2.1.0"
+  checksum: 10c0/26ae49cf448e807e454a9bdea5a9dfdcf669e2fdbf2df341900a0fb693c5662fea7e39db3227ce8972d1bda0ba7da9b7410e5163b12d8878a579548d847220ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
peer dependency, so that websockets can
use a different ioredis than BullMQ
(just ran into a type issue when
a consuming project updated the minor
version of ioredis and attempted to
pass a connection built off of that
ioredis into BullMQ.