### PR TITLE
feat(websockets): per-environment transport adapter seam (Redis / in-process)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.2.0
+
+- Adds a per-environment websockets transport **adapter seam**, modeled on Rails ActionCable's `cable.yml`. The transport is now selected per environment instead of always using Redis:
+  - `RedisWebsocketsAdapter` — the default in `development` and `production`. Unchanged behavior: the socket registry and broadcasts go through Redis (`@socket.io/redis-emitter` + `@socket.io/redis-adapter`).
+  - `InProcessWebsocketsAdapter` — the default in `test`. Keeps the registry in memory, records every broadcast for assertions, and delivers in-process via the attached socket.io server when one exists. Unit specs do **zero Redis I/O**, and feature specs still get real end-to-end delivery with no external Redis.
+- **The `test` environment now defaults to the in-process adapter.** This removes a class of intermittent spec failures caused by unit specs emitting to Redis for no effect (no sockets are connected). No code change is required on upgrade. If a project relied on real Redis behavior in `test`, opt back in with `wsApp.set('adapter', 'redis')`. Select the adapter explicitly in any environment with `wsApp.set('adapter', 'redis' | 'in_process' | <instance>)` (or pass a custom adapter instance). For fully hermetic specs, also stop opening a Redis connection in `test` (gate `wsApp.set('connection', …)` behind `!AppEnv.isTest`), so no Redis socket is created at init.
+- New `@rvoh/psychic-websockets/testing` entrypoint: `websocketBroadcasts(path?)`, `assertBroadcast(path, { to?, prefix?, data? })`, and `clearBroadcasts()` for asserting on the broadcasts recorded by the in-process adapter.
+- Public API is unchanged: `new Ws(paths)`, `ws.emit`, `Ws.register`, and `wsApp.set('connection', …)` behave as before; production with a connection and no explicit adapter resolves to the Redis adapter, identical to prior releases.
+
 ## 3.1.0
 
 - We recommend you pass cors options yourself, since the types are no longer congruent. If cors configuration is needed, it should be set up in the websockets config, using `wsApp.set('socketioOptions', { cors: ... })`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-websockets",
   "description": "Websocket system for Psychic applications",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "RVO Health",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
       "types": "./dist/types/src/index.d.ts",
       "import": "./dist/esm/src/index.js",
       "require": "./dist/cjs/src/index.js"
+    },
+    "./testing": {
+      "types": "./dist/types/src/testing/index.d.ts",
+      "import": "./dist/esm/src/testing/index.js",
+      "require": "./dist/cjs/src/testing/index.js"
     }
   },
   "files": [

--- a/spec/unit/cable/adapter/InProcessWebsocketsAdapter.spec.ts
+++ b/spec/unit/cable/adapter/InProcessWebsocketsAdapter.spec.ts
@@ -1,0 +1,128 @@
+import InProcessWebsocketsAdapter from '../../../../src/cable/adapter/InProcessWebsocketsAdapter.js'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fakeSocket(id: string, on: (...args: any[]) => void = vi.fn()): any {
+  return { id, on }
+}
+
+// a minimal stand-in for the socket.io server: io.of(namespace).to(socketId).emit(path, data)
+function fakeSocketServer() {
+  const emit = vi.fn()
+  const to = vi.fn().mockReturnValue({ emit })
+  const of = vi.fn().mockReturnValue({ to })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { server: { of } as any, of, to, emit }
+}
+
+describe('InProcessWebsocketsAdapter', () => {
+  let adapter: InProcessWebsocketsAdapter
+
+  beforeEach(() => {
+    adapter = new InProcessWebsocketsAdapter()
+  })
+
+  describe('#register / #socketIdsFor', () => {
+    it('tracks registered socket ids in memory per user key', async () => {
+      await adapter.register('user:123', fakeSocket('456'))
+      await adapter.register('user:123', fakeSocket('789'))
+      await adapter.register('user:other', fakeSocket('101'))
+
+      expect(await adapter.socketIdsFor('user:123')).toEqual(['456', '789'])
+      expect(await adapter.socketIdsFor('user:other')).toEqual(['101'])
+    })
+
+    it('dedupes repeated socket ids', async () => {
+      await adapter.register('user:123', fakeSocket('456'))
+      await adapter.register('user:123', fakeSocket('456'))
+
+      expect(await adapter.socketIdsFor('user:123')).toEqual(['456'])
+    })
+
+    it('removes the socket id on disconnect', async () => {
+      let disconnect: () => void = () => {}
+      const on = vi.fn((event: string, cb: () => void) => {
+        if (event === 'disconnect') disconnect = cb
+      })
+      await adapter.register('user:123', fakeSocket('456', on))
+      expect(await adapter.socketIdsFor('user:123')).toEqual(['456'])
+
+      disconnect()
+
+      expect(await adapter.socketIdsFor('user:123')).toEqual([])
+    })
+
+    context('for an unknown user key', () => {
+      it('returns an empty array', async () => {
+        expect(await adapter.socketIdsFor('user:nope')).toEqual([])
+      })
+    })
+  })
+
+  describe('#emit', () => {
+    it('records every broadcast', async () => {
+      await adapter.emit('/', 'user:123', '/ops/howyadoin', { hello: 'world' })
+
+      expect(adapter.broadcasts).toEqual([
+        { namespace: '/', userKey: 'user:123', path: '/ops/howyadoin', data: { hello: 'world' } },
+      ])
+    })
+
+    context('without an attached server', () => {
+      it('records but performs no delivery', async () => {
+        await adapter.register('user:123', fakeSocket('456'))
+
+        await adapter.emit('/', 'user:123', '/ops/howyadoin', { hello: 'world' })
+
+        expect(adapter.broadcasts).toHaveLength(1)
+      })
+    })
+
+    context('with an attached server', () => {
+      it('delivers in-process to each registered socket within the namespace', async () => {
+        const io = fakeSocketServer()
+        adapter.attachServer(io.server)
+        await adapter.register('user:123', fakeSocket('456'))
+
+        await adapter.emit('/', 'user:123', '/ops/howyadoin', { hello: 'world' })
+
+        expect(io.of).toHaveBeenCalledWith('/')
+        expect(io.to).toHaveBeenCalledWith('456')
+        expect(io.emit).toHaveBeenCalledWith('/ops/howyadoin', { hello: 'world' })
+        expect(adapter.broadcasts).toHaveLength(1)
+      })
+    })
+  })
+
+  describe('#clearBroadcasts', () => {
+    it('empties the recorded broadcasts without detaching the server', async () => {
+      const io = fakeSocketServer()
+      adapter.attachServer(io.server)
+      await adapter.emit('/', 'user:123', '/x', {})
+
+      adapter.clearBroadcasts()
+
+      expect(adapter.broadcasts).toEqual([])
+      // server still attached: a subsequent emit still records
+      await adapter.emit('/', 'user:123', '/y', {})
+      expect(adapter.broadcasts).toHaveLength(1)
+    })
+  })
+
+  describe('#shutdown', () => {
+    it('clears the registry, broadcasts, and detaches the server', async () => {
+      const io = fakeSocketServer()
+      adapter.attachServer(io.server)
+      await adapter.register('user:123', fakeSocket('456'))
+      await adapter.emit('/', 'user:123', '/x', {})
+
+      await adapter.shutdown()
+
+      expect(adapter.broadcasts).toEqual([])
+      expect(await adapter.socketIdsFor('user:123')).toEqual([])
+
+      io.of.mockClear()
+      await adapter.emit('/', 'user:123', '/x', {})
+      expect(io.of).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/spec/unit/cable/adapter/RedisWebsocketsAdapter.spec.ts
+++ b/spec/unit/cable/adapter/RedisWebsocketsAdapter.spec.ts
@@ -1,0 +1,119 @@
+import { sort } from '@rvoh/dream/utils'
+import { Redis } from 'ioredis'
+import RedisWebsocketsAdapter from '../../../../src/cable/adapter/RedisWebsocketsAdapter.js'
+import MissingWsRedisConnection from '../../../../src/error/ws/MissingWsRedisConnection.js'
+import PsychicAppWebsockets from '../../../../src/psychic-app-websockets/index.js'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fakeSocket(id: string, on: (...args: any[]) => void = vi.fn()): any {
+  return { id, on }
+}
+
+describe('RedisWebsocketsAdapter', () => {
+  let adapter: RedisWebsocketsAdapter
+
+  beforeEach(async () => {
+    const wsApp = PsychicAppWebsockets.getOrFail()
+    wsApp.set('connection', new Redis({ maxRetriesPerRequest: null }))
+    wsApp.set('adapter', 'redis')
+    adapter = wsApp.adapter() as RedisWebsocketsAdapter
+
+    const connection = wsApp.connection
+    await connection.del('user:123:socket_ids')
+    await connection.del('user:otheruserid:socket_ids')
+    await connection.del('user:150:socket_ids')
+  })
+
+  afterEach(() => {
+    const wsApp = PsychicAppWebsockets.getOrFail()
+    wsApp.connection?.disconnect()
+    wsApp.subConnection?.disconnect()
+  })
+
+  describe('#register', () => {
+    it('stores the socket id in redis under the user key', async () => {
+      await adapter.register('user:123', fakeSocket('456'))
+      await adapter.register('user:123', fakeSocket('789'))
+      await adapter.register('user:otheruserid', fakeSocket('101'))
+
+      expect(await adapter.socketIdsFor('user:123')).toEqual(['456', '789'])
+      expect(await adapter.socketIdsFor('user:otheruserid')).toEqual(['101'])
+    })
+
+    context('with more than 3 register calls for the same user', () => {
+      it('restricts to 3 socket ids per user key', async () => {
+        await adapter.register('user:123', fakeSocket('456'))
+        await adapter.register('user:123', fakeSocket('789'))
+        await adapter.register('user:123', fakeSocket('345'))
+        await adapter.register('user:123', fakeSocket('234'))
+
+        expect(sort(await adapter.socketIdsFor('user:123'))).toEqual(['234', '345', '789'])
+      })
+    })
+
+    it('binds disconnect cleanup to the socket', async () => {
+      const onSpy = vi.fn()
+      await adapter.register('user:123', fakeSocket('456', onSpy))
+
+      // NOTE: a real disconnect round-trip would need an end-to-end test; here we
+      // only assert the cleanup handler was bound.
+      expect(onSpy).toHaveBeenCalledWith('disconnect', expect.any(Function))
+    })
+  })
+
+  describe('#socketIdsFor', () => {
+    it('reads the socket ids stored under the user key', async () => {
+      const connection = PsychicAppWebsockets.getOrFail().connection
+      await connection.rpush('user:150:socket_ids', '151')
+
+      expect(await adapter.socketIdsFor('user:150')).toEqual(['151'])
+    })
+
+    context('for a user with no registered socket ids', () => {
+      it('returns an empty array', async () => {
+        expect(await adapter.socketIdsFor('user:123')).toEqual([])
+      })
+    })
+  })
+
+  describe('#emit', () => {
+    it('emits to each registered socket id within the namespace', async () => {
+      const emitSpy = vi.fn()
+      const toSpy = vi.fn().mockReturnValue({ emit: emitSpy })
+      const ofSpy = vi.fn().mockReturnValue({ to: toSpy })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      vi.spyOn(adapter as any, 'emitter').mockReturnValue({ of: ofSpy })
+      vi.spyOn(adapter, 'socketIdsFor').mockResolvedValue(['456'])
+
+      await adapter.emit('/', 'user:123', '/ops/howyadoin', { hello: 'world' })
+
+      expect(ofSpy).toHaveBeenCalledWith('/')
+      expect(toSpy).toHaveBeenCalledWith('456')
+      expect(emitSpy).toHaveBeenCalledWith('/ops/howyadoin', { hello: 'world' })
+    })
+
+    context('when no socket ids are registered', () => {
+      it('does not build an emitter', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const emitterSpy = vi.spyOn(adapter as any, 'emitter')
+        vi.spyOn(adapter, 'socketIdsFor').mockResolvedValue([])
+
+        await adapter.emit('/', 'user:123', '/ops/howyadoin', { hello: 'world' })
+
+        expect(emitterSpy).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('#attachServer', () => {
+    context('without a redis connection', () => {
+      it('raises MissingWsRedisConnection', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        PsychicAppWebsockets.getOrFail().set('connection', undefined as any)
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(() => adapter.attachServer({} as any)).toThrowError(MissingWsRedisConnection)
+      })
+    })
+  })
+})

--- a/spec/unit/cable/inProcessDelivery.spec.ts
+++ b/spec/unit/cable/inProcessDelivery.spec.ts
@@ -1,0 +1,62 @@
+import { io as ioClient, Socket as ClientSocket } from 'socket.io-client'
+import InProcessWebsocketsAdapter from '../../../src/cable/adapter/InProcessWebsocketsAdapter.js'
+import Cable from '../../../src/cable/index.js'
+import Ws from '../../../src/cable/ws.js'
+import PsychicAppWebsockets from '../../../src/psychic-app-websockets/index.js'
+
+// End-to-end proof that the in-process adapter (the default in test) delivers real
+// websocket broadcasts over a real socket.io connection with NO redis involved —
+// the same guarantee the puppeteer feature spec covers, but without a browser.
+describe('in-process websocket delivery (end-to-end, no redis)', () => {
+  const port = 9971
+  let cable: Cable
+  let client: ClientSocket | undefined
+
+  beforeEach(() => {
+    const wsApp = PsychicAppWebsockets.getOrFail()
+    wsApp.on('ws:start', server => {
+      server.of('/').on('connection', async socket => {
+        const userId = socket.handshake.auth.userId as string
+        await Ws.register(socket, userId)
+        const ws = new Ws(['/ops/connection-success'] as const)
+        await ws.emit(userId, '/ops/connection-success', { message: 'connected' })
+      })
+    })
+
+    cable = new Cable()
+  })
+
+  afterEach(async () => {
+    client?.disconnect()
+    client = undefined
+    await cable.stop()
+  })
+
+  it('delivers an emit to the connected socket and records it, without any redis', async () => {
+    await cable.start(port)
+
+    const received = await new Promise<{ message: string }>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timed out waiting for broadcast')), 8000)
+      client = ioClient(`http://localhost:${port}`, { auth: { userId: '123' }, transports: ['websocket'] })
+      client.on('/ops/connection-success', (data: { message: string }) => {
+        clearTimeout(timeout)
+        resolve(data)
+      })
+      client.on('connect_error', error => {
+        clearTimeout(timeout)
+        reject(error instanceof Error ? error : new Error(String(error)))
+      })
+    })
+
+    expect(received).toEqual({ message: 'connected' })
+
+    const adapter = PsychicAppWebsockets.getOrFail().adapter()
+    expect(adapter).toBeInstanceOf(InProcessWebsocketsAdapter)
+    expect((adapter as InProcessWebsocketsAdapter).broadcasts).toContainEqual({
+      namespace: '/',
+      userKey: 'user:123',
+      path: '/ops/connection-success',
+      data: { message: 'connected' },
+    })
+  }, 15000)
+})

--- a/spec/unit/cable/ws.spec.ts
+++ b/spec/unit/cable/ws.spec.ts
@@ -1,169 +1,137 @@
-import { DateTime } from '@rvoh/dream'
-import { sort } from '@rvoh/dream/utils'
-import { MockInstance } from 'vitest'
-import redisWsKey, * as RedisWsKeyModule from '../../../src/cable/redisWsKey.js'
 import Ws from '../../../src/cable/ws.js'
 import InvalidWsPathError from '../../../src/error/ws/InvalidWsPathError.js'
 import PsychicAppWebsockets from '../../../src/psychic-app-websockets/index.js'
 import createUser from '../../../test-app/spec/factories/UserFactory.js'
 
+// `Ws` is a thin facade: it validates paths, shapes the namespaced user key, and
+// delegates registry + delivery to whichever adapter is active for the environment
+// (in-process in test). These specs assert that delegation; the adapters' own
+// behavior is covered in spec/unit/cable/adapter/*.
+function activeAdapter() {
+  return PsychicAppWebsockets.getOrFail().adapter()
+}
+
 describe('Ws', () => {
   describe('.register', () => {
-    beforeEach(async () => {
-      const psychicApp = PsychicAppWebsockets.getOrFail()
-      const redisClient = psychicApp.connection
-      await redisClient.del(`user:123:socket_ids`)
-      await redisClient.del(`user:otheruserid:socket_ids`)
+    it('delegates to the adapter with the default-prefixed user key', async () => {
+      const registerSpy = vi.spyOn(activeAdapter(), 'register').mockResolvedValue()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+      const socket: any = { id: '456', on: vi.fn() }
+
+      await Ws.register(socket, '123')
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      expect(registerSpy).toHaveBeenCalledWith('user:123', socket)
     })
 
-    it('puts socket id in redis', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-      await Ws.register({ id: '456', on: vi.fn() } as any, '123')
+    context('with a custom redisKeyPrefix', () => {
+      it('namespaces the user key with the custom prefix', async () => {
+        const registerSpy = vi.spyOn(activeAdapter(), 'register').mockResolvedValue()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+        const socket: any = { id: '456', on: vi.fn() }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-      await Ws.register({ id: '789', on: vi.fn() } as any, '123')
+        await Ws.register(socket, '123', 'admin-user')
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-      await Ws.register({ id: '101', on: vi.fn() } as any, 'otheruserid')
-
-      const socketIds = await new Ws([]).findSocketIds('123')
-      expect(socketIds).toEqual(['456', '789'])
-    })
-
-    context('with more than 3 register calls for the same user', () => {
-      it('restricts to 3 per unique id', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        await Ws.register({ id: '456', on: vi.fn() } as any, '123')
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        await Ws.register({ id: '789', on: vi.fn() } as any, '123')
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        await Ws.register({ id: '345', on: vi.fn() } as any, '123')
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        await Ws.register({ id: '234', on: vi.fn() } as any, '123')
-
-        const socketIds = await new Ws([]).findSocketIds('123')
-        expect(sort(socketIds)).toEqual(['234', '345', '789'])
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        expect(registerSpy).toHaveBeenCalledWith('admin-user:123', socket)
       })
     })
 
-    it('binds disconnect logic to socket', async () => {
-      const onSpy = vi.fn()
+    context('when passed a dream', () => {
+      it('uses the primaryKeyValue of that dream', async () => {
+        const user = await createUser()
+        const registerSpy = vi.spyOn(activeAdapter(), 'register').mockResolvedValue()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+        const socket: any = { id: '456', on: vi.fn() }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-      await Ws.register({ id: '456', on: onSpy } as any, '123')
+        await Ws.register(socket, user)
 
-      // NOTE: would be better to get a solid test around disconnection behavior, but that would need to be
-      // an end-to-end test.
-      expect(onSpy).toHaveBeenCalledWith('disconnect', expect.any(Function))
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        expect(registerSpy).toHaveBeenCalledWith(`user:${user.id}`, socket)
+      })
     })
   })
 
   describe('#emit', () => {
-    let ws: Ws<readonly string[]>
-    let findSocketIdsSpy: MockInstance
-    let toSpy: MockInstance
-    let emitSpy: MockInstance
+    it('delegates to the adapter with namespace, user key, path, and data', async () => {
+      const emitSpy = vi.spyOn(activeAdapter(), 'emit').mockResolvedValue()
+      const ws = new Ws(['/ops/howyadoin'] as const)
 
-    function buildWsInstanceForEmitTests(findSocketIdsValue: string[]) {
-      ws = new Ws(['/ops/howyadoin'] as const)
-      ws.boot()
-
-      findSocketIdsSpy = vi.spyOn(ws, 'findSocketIds').mockResolvedValue(findSocketIdsValue)
-      emitSpy = vi.fn()
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-      toSpy = vi.spyOn(ws.io, 'to').mockReturnValue({ emit: emitSpy } as any)
-    }
-
-    it('emits to the passed id to the default socket.io namespace, using "user" (by default) as the redis key prefix', async () => {
-      buildWsInstanceForEmitTests(['456'])
       await ws.emit(123, '/ops/howyadoin', { hello: 'world' })
-      expect(findSocketIdsSpy).toHaveBeenCalledWith('123')
-      expect(toSpy).toHaveBeenCalledWith('456')
-      expect(emitSpy).toHaveBeenCalledWith('/ops/howyadoin', { hello: 'world' })
+
+      expect(emitSpy).toHaveBeenCalledWith('/', 'user:123', '/ops/howyadoin', { hello: 'world' })
     })
 
-    context('findSocketIds does not find any socket ids for the user', () => {
-      it('does not emit to the passed id with the "user" namespace', async () => {
-        buildWsInstanceForEmitTests([])
+    context('with a custom namespace and redisKeyPrefix', () => {
+      it('passes both through to the adapter', async () => {
+        const emitSpy = vi.spyOn(activeAdapter(), 'emit').mockResolvedValue()
+        const ws = new Ws(['/ops/howyadoin'] as const, { namespace: '/admin', redisKeyPrefix: 'admin-user' })
+
         await ws.emit(123, '/ops/howyadoin', { hello: 'world' })
-        expect(toSpy).not.toHaveBeenCalled()
-        expect(emitSpy).not.toHaveBeenCalled()
+
+        expect(emitSpy).toHaveBeenCalledWith('/admin', 'admin-user:123', '/ops/howyadoin', { hello: 'world' })
       })
     })
 
     context('when passed a dream', () => {
       it('emits to the primaryKeyValue of that dream', async () => {
         const user = await createUser()
-        buildWsInstanceForEmitTests(['456'])
+        const emitSpy = vi.spyOn(activeAdapter(), 'emit').mockResolvedValue()
+        const ws = new Ws(['/ops/howyadoin'] as const)
+
         await ws.emit(user, '/ops/howyadoin', { hello: 'world' })
-        expect(toSpy).toHaveBeenCalledWith('456')
-        expect(findSocketIdsSpy).toHaveBeenCalledWith(user.id)
-        expect(emitSpy).toHaveBeenCalledWith('/ops/howyadoin', { hello: 'world' })
+
+        expect(emitSpy).toHaveBeenCalledWith('/', `user:${user.id}`, '/ops/howyadoin', { hello: 'world' })
       })
     })
 
     context('when passed an invalid path', () => {
-      it('raises an exception', async () => {
-        const user = await createUser()
-        buildWsInstanceForEmitTests(['456'])
+      it('raises an exception and does not delegate to the adapter', async () => {
+        const emitSpy = vi.spyOn(activeAdapter(), 'emit').mockResolvedValue()
+        const ws = new Ws(['/ops/howyadoin'] as const)
 
         await expect(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ws.emit(user, '/ops/whoopsthisiswrong' as any, { hello: 'world' }),
+          ws.emit(123, '/ops/whoopsthisiswrong' as any, { hello: 'world' }),
         ).rejects.toThrowError(InvalidWsPathError)
+        expect(emitSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    context('with no allowed paths configured', () => {
+      it('permits any path', async () => {
+        const emitSpy = vi.spyOn(activeAdapter(), 'emit').mockResolvedValue()
+        const ws = new Ws([] as const)
+        // with no allowed paths every path is permitted at runtime; call through a
+        // loosened signature since the generic path constraint resolves to `never`.
+        const emit = ws.emit.bind(ws) as (id: number, path: string, data: unknown) => Promise<void>
+
+        await emit(123, '/anything/goes', { hello: 'world' })
+
+        expect(emitSpy).toHaveBeenCalledWith('/', 'user:123', '/anything/goes', { hello: 'world' })
       })
     })
   })
 
   describe('#findSocketIds', () => {
-    let ws: Ws<[]>
-    beforeEach(async () => {
-      const psychicAppWebsockets = PsychicAppWebsockets.getOrFail()
-      const redisClient = psychicAppWebsockets.connection
+    it('delegates to the adapter with the default-prefixed user key', async () => {
+      const socketIdsForSpy = vi.spyOn(activeAdapter(), 'socketIdsFor').mockResolvedValue(['151'])
+      const ws = new Ws([] as const)
 
-      const key = redisWsKey('150', 'user')
-      const otherKey = redisWsKey('160', 'howyadoin')
-
-      await redisClient
-        .multi()
-        .rpush(key, '151')
-        .expireat(key, DateTime.now().plus({ seconds: 15 }).toSeconds())
-        .exec()
-
-      await redisClient
-        .multi()
-        .rpush(otherKey, '161')
-        .expireat(key, DateTime.now().plus({ seconds: 15 }).toSeconds())
-        .exec()
-
-      ws = new Ws([] as const)
-      ws.boot()
-    })
-
-    it('calls to redis to find socket ids', async () => {
-      const redisWsKeySpy = vi.spyOn(RedisWsKeyModule, 'default')
       const socketIds = await ws.findSocketIds('150')
+
       expect(socketIds).toEqual(['151'])
-      expect(redisWsKeySpy).toHaveBeenCalledWith('150', 'user')
+      expect(socketIdsForSpy).toHaveBeenCalledWith('user:150')
     })
 
     context('with a custom redisKeyPrefix', () => {
-      it('uses the custom prefix to generate the redis key', async () => {
-        const redisWsKeySpy = vi.spyOn(RedisWsKeyModule, 'default')
-        ws = new Ws([] as const, { redisKeyPrefix: 'howyadoin' })
-        const socketIds = await ws.findSocketIds('160')
-        expect(socketIds).toEqual(['161'])
-        expect(redisWsKeySpy).toHaveBeenCalledWith('160', 'howyadoin')
-      })
-    })
+      it('uses the custom prefix to build the user key', async () => {
+        const socketIdsForSpy = vi.spyOn(activeAdapter(), 'socketIdsFor').mockResolvedValue(['161'])
+        const ws = new Ws([] as const, { redisKeyPrefix: 'howyadoin' })
 
-    context('for a user with no registered socket ids', () => {
-      it('returns a blank array', async () => {
-        const socketIds = await ws.findSocketIds('123123123')
-        expect(socketIds).toEqual([])
+        await ws.findSocketIds('160')
+
+        expect(socketIdsForSpy).toHaveBeenCalledWith('howyadoin:160')
       })
     })
   })

--- a/src/cable/adapter/InProcessWebsocketsAdapter.ts
+++ b/src/cable/adapter/InProcessWebsocketsAdapter.ts
@@ -1,0 +1,85 @@
+import { Server as SocketServer, Socket } from 'socket.io'
+import { PsychicWebsocketsAdapter } from './PsychicWebsocketsAdapter.js'
+
+/**
+ * A single recorded broadcast, captured by {@link InProcessWebsocketsAdapter} every
+ * time something emits. Assertable in specs via the `./testing` helpers.
+ */
+export interface RecordedBroadcast {
+  namespace: string
+  userKey: string
+  path: string
+  data: unknown
+}
+
+/**
+ * In-process websockets adapter (test default; also selectable for development).
+ * This is Rails' "the test adapter extends the async adapter" idea in one class:
+ *
+ *   - it keeps the user-key → socket-id registry in memory (no redis I/O), so unit
+ *     specs that emit through backgrounded app flows do zero external work;
+ *   - it records every broadcast into {@link broadcasts} so specs can assert on what
+ *     would have been delivered; and
+ *   - when a socket.io server has been attached (i.e. {@link Cable} actually started,
+ *     as in feature specs), it ALSO delivers each broadcast in-process to the live
+ *     sockets — giving real end-to-end delivery with no external redis.
+ */
+export default class InProcessWebsocketsAdapter implements PsychicWebsocketsAdapter {
+  /**
+   * every broadcast emitted while this adapter is active, in order. Read/cleared
+   * through the `@rvoh/psychic-websockets/testing` helpers.
+   */
+  public broadcasts: RecordedBroadcast[] = []
+
+  private registry = new Map<string, Set<string>>()
+  private io: SocketServer | undefined
+
+  public register(userKey: string, socket: Socket): Promise<void> {
+    let socketIds = this.registry.get(userKey)
+    if (!socketIds) {
+      socketIds = new Set<string>()
+      this.registry.set(userKey, socketIds)
+    }
+    socketIds.add(socket.id)
+
+    socket.on('disconnect', () => {
+      this.registry.get(userKey)?.delete(socket.id)
+    })
+
+    return Promise.resolve()
+  }
+
+  public socketIdsFor(userKey: string): Promise<string[]> {
+    return Promise.resolve([...(this.registry.get(userKey) ?? [])])
+  }
+
+  public async emit(namespace: string, userKey: string, path: string, data: unknown): Promise<void> {
+    this.broadcasts.push({ namespace, userKey, path, data })
+
+    if (!this.io) return
+
+    const socketIds = await this.socketIdsFor(userKey)
+    for (const socketId of socketIds) {
+      this.io.of(namespace).to(socketId).emit(path, data)
+    }
+  }
+
+  public attachServer(io: SocketServer): void {
+    this.io = io
+  }
+
+  public shutdown(): Promise<void> {
+    this.io = undefined
+    this.registry.clear()
+    this.broadcasts = []
+    return Promise.resolve()
+  }
+
+  /**
+   * clears recorded broadcasts without otherwise tearing down the adapter. Used by
+   * the `./testing` `clearBroadcasts()` helper between assertions.
+   */
+  public clearBroadcasts(): void {
+    this.broadcasts = []
+  }
+}

--- a/src/cable/adapter/PsychicWebsocketsAdapter.ts
+++ b/src/cable/adapter/PsychicWebsocketsAdapter.ts
@@ -1,0 +1,47 @@
+import { Server as SocketServer, Socket } from 'socket.io'
+
+/**
+ * A websockets transport adapter, selected per environment (modeled on Rails'
+ * ActionCable `cable.yml`). Psychic ships two implementations:
+ *
+ *   - {@link RedisWebsocketsAdapter} — distributes registry + broadcasts through
+ *     redis (production default).
+ *   - {@link InProcessWebsocketsAdapter} — keeps the registry in memory, records
+ *     every broadcast for assertions, and delivers in-process through the attached
+ *     socket.io server when one exists (test default).
+ *
+ * A `userKey` is the namespaced identity a socket is registered against, e.g.
+ * `user:123` (built from the id and the `redisKeyPrefix` by {@link Ws}). Adapters
+ * treat it as an opaque key.
+ */
+export interface PsychicWebsocketsAdapter {
+  /**
+   * binds a socket to the given namespaced user key, so subsequent emits to that
+   * user reach this socket. Should also clean up the binding on `disconnect`.
+   */
+  register(userKey: string, socket: Socket): Promise<void>
+
+  /**
+   * returns the socket ids currently registered for the given namespaced user key.
+   */
+  socketIdsFor(userKey: string): Promise<string[]>
+
+  /**
+   * delivers `data` on `path` to every socket registered for `userKey` within the
+   * given socket.io `namespace`.
+   */
+  emit(namespace: string, userKey: string, path: string, data: unknown): Promise<void>
+
+  /**
+   * hands the in-process socket.io server to the adapter when {@link Cable} starts.
+   * The redis adapter uses it to install the redis socket.io adapter; the in-process
+   * adapter stores it to deliver broadcasts directly.
+   */
+  attachServer(io: SocketServer): void
+
+  /**
+   * tears down any resources held by the adapter (redis connections, in-memory
+   * state) when {@link Cable} stops.
+   */
+  shutdown(): Promise<void>
+}

--- a/src/cable/adapter/RedisWebsocketsAdapter.ts
+++ b/src/cable/adapter/RedisWebsocketsAdapter.ts
@@ -1,0 +1,138 @@
+import { DateTime } from '@rvoh/dream'
+import { uniq } from '@rvoh/dream/utils'
+import { createAdapter } from '@socket.io/redis-adapter'
+import { Emitter } from '@socket.io/redis-emitter'
+import { Redis } from 'ioredis'
+import { Server as SocketServer, Socket } from 'socket.io'
+import MissingWsRedisConnection from '../../error/ws/MissingWsRedisConnection.js'
+import EnvInternal from '../../helpers/EnvInternal.js'
+import PsychicAppWebsockets, { RedisOrRedisClusterConnection } from '../../psychic-app-websockets/index.js'
+import { PsychicWebsocketsAdapter } from './PsychicWebsocketsAdapter.js'
+
+/**
+ * Production websockets adapter. Stores the user-key → socket-id registry in redis
+ * and broadcasts through `@socket.io/redis-emitter`, so a clustered fleet of
+ * websocket processes can all deliver to a connected socket. This is the behavior
+ * Psychic shipped before the adapter seam existed.
+ */
+export default class RedisWebsocketsAdapter implements PsychicWebsocketsAdapter {
+  private redisConnections: RedisOrRedisClusterConnection[] = []
+  private _emitter: Emitter | undefined
+  private _emitterConnection: RedisOrRedisClusterConnection | undefined
+
+  public async register(userKey: string, socket: Socket): Promise<void> {
+    const connection = this.connection
+    const redisKey = this.redisKey(userKey)
+
+    const socketIdsToKeep = await connection.lrange(redisKey, -2, -1)
+
+    await connection
+      .multi()
+      .del(redisKey)
+      .rpush(redisKey, ...socketIdsToKeep, socket.id)
+      .expireat(
+        redisKey,
+        // TODO: make this configurable in non-test environments
+        DateTime.now()
+          .plus(EnvInternal.isTest ? { seconds: 15 } : { day: 1 })
+          .toSeconds(),
+      )
+      .exec()
+
+    socket.on('disconnect', () => {
+      void connection.lrem(redisKey, 1, socket.id)
+    })
+  }
+
+  public async socketIdsFor(userKey: string): Promise<string[]> {
+    return uniq(await this.connection.lrange(this.redisKey(userKey), 0, -1))
+  }
+
+  public async emit(namespace: string, userKey: string, path: string, data: unknown): Promise<void> {
+    const socketIds = await this.socketIdsFor(userKey)
+    if (!socketIds.length) return
+
+    const emitter = this.emitter().of(namespace)
+    for (const socketId of socketIds) {
+      emitter.to(socketId).emit(path, data)
+    }
+  }
+
+  public attachServer(io: SocketServer): void {
+    const wsApp = PsychicAppWebsockets.getOrFail()
+    const pubClient = wsApp.connection
+    const subClient = wsApp.subConnection
+
+    if (!pubClient || !subClient) throw new MissingWsRedisConnection()
+
+    this.redisConnections.push(pubClient)
+    this.redisConnections.push(subClient)
+
+    pubClient.on('error', (error: unknown) => {
+      PsychicAppWebsockets.log('PUB CLIENT ERROR', error)
+    })
+    // subConnection is `Redis | Cluster`; both expose `.on('error', …)`, but the
+    // union's listener overloads aren't directly callable, so narrow to Redis.
+    ;(subClient as Redis).on('error', (error: unknown) => {
+      PsychicAppWebsockets.log('sub CLIENT ERROR', error)
+    })
+
+    try {
+      io.adapter(createAdapter(pubClient, subClient))
+    } catch (error) {
+      PsychicAppWebsockets.log('FAILED TO ADAPT', error)
+    }
+  }
+
+  public async shutdown(): Promise<void> {
+    for (const connection of this.redisConnections) {
+      try {
+        connection.disconnect()
+      } catch {
+        // noop
+      }
+    }
+
+    this.redisConnections = []
+    this._emitter = undefined
+    this._emitterConnection = undefined
+
+    return Promise.resolve()
+  }
+
+  /**
+   * @internal
+   *
+   * the redis connection used for the registry + emitter, read fresh from the
+   * websockets app so a replaced connection is always honored.
+   */
+  private get connection() {
+    const connection = PsychicAppWebsockets.getOrFail().connection
+    if (!connection) throw new MissingWsRedisConnection()
+    return connection
+  }
+
+  /**
+   * @internal
+   *
+   * lazily builds (and caches) the redis emitter, rebuilding if the underlying
+   * connection has been swapped out.
+   */
+  private emitter(): Emitter {
+    const connection = this.connection
+    if (!this._emitter || this._emitterConnection !== connection) {
+      this._emitter = new Emitter(connection)
+      this._emitterConnection = connection
+    }
+    return this._emitter
+  }
+
+  /**
+   * @internal
+   *
+   * the redis key under which a user's socket ids are stored.
+   */
+  private redisKey(userKey: string): string {
+    return `${userKey}:socket_ids`
+  }
+}

--- a/src/cable/adapter/resolveWebsocketsAdapter.ts
+++ b/src/cable/adapter/resolveWebsocketsAdapter.ts
@@ -1,0 +1,34 @@
+import EnvInternal from '../../helpers/EnvInternal.js'
+import InProcessWebsocketsAdapter from './InProcessWebsocketsAdapter.js'
+import { PsychicWebsocketsAdapter } from './PsychicWebsocketsAdapter.js'
+import RedisWebsocketsAdapter from './RedisWebsocketsAdapter.js'
+
+/**
+ * What an app may pass to `wsApp.set('adapter', ...)`: one of the two built-in
+ * adapter names, or a custom adapter instance.
+ */
+export type WebsocketsAdapterSelector = 'redis' | 'in_process' | PsychicWebsocketsAdapter
+
+/**
+ * Resolves the configured adapter selector to a concrete adapter instance,
+ * cable.yml-style. When nothing is configured, the default is environment-based:
+ *
+ *   - `test`        → in-process (hermetic specs, no redis)
+ *   - `development` → redis (kept faithful to production)
+ *   - `production`  → redis
+ *
+ * Override per environment with `wsApp.set('adapter', 'redis' | 'in_process')` or by
+ * passing a custom {@link PsychicWebsocketsAdapter} instance.
+ */
+export default function resolveWebsocketsAdapter(
+  selector: WebsocketsAdapterSelector | undefined,
+): PsychicWebsocketsAdapter {
+  if (selector === undefined) {
+    return EnvInternal.isTest ? new InProcessWebsocketsAdapter() : new RedisWebsocketsAdapter()
+  }
+
+  if (selector === 'redis') return new RedisWebsocketsAdapter()
+  if (selector === 'in_process') return new InProcessWebsocketsAdapter()
+
+  return selector
+}

--- a/src/cable/index.ts
+++ b/src/cable/index.ts
@@ -2,19 +2,16 @@ import { DreamCLI } from '@rvoh/dream/system'
 import { PsychicApp } from '@rvoh/psychic'
 import { PsychicLogos } from '@rvoh/psychic/system'
 import { colorize } from '@rvoh/psychic/utils'
-import { createAdapter } from '@socket.io/redis-adapter'
 import * as fs from 'node:fs'
 import * as http from 'node:http'
 import * as https from 'node:https'
 import * as socketio from 'socket.io'
-import MissingWsRedisConnection from '../error/ws/MissingWsRedisConnection.js'
 import EnvInternal from '../helpers/EnvInternal.js'
-import PsychicAppWebsockets, { RedisOrRedisClusterConnection } from '../psychic-app-websockets/index.js'
+import PsychicAppWebsockets from '../psychic-app-websockets/index.js'
 
 export default class Cable {
   public io: socketio.Server | undefined
   public httpServer: http.Server
-  private redisConnections: RedisOrRedisClusterConnection[] = []
 
   /**
    * @internal
@@ -98,13 +95,14 @@ export default class Cable {
       }
     })
 
-    this.bindToRedis()
+    config.adapter().attachServer(this.io!)
 
     await this.listen({ port })
   }
 
   /**
-   * stops the socket.io server, closing out of all redis connections
+   * stops the socket.io server and tears down the active websockets adapter
+   * (closing redis connections when the redis adapter is in use)
    */
   public async stop() {
     try {
@@ -113,12 +111,10 @@ export default class Cable {
       // noop
     }
 
-    for (const connection of this.redisConnections) {
-      try {
-        connection.disconnect()
-      } catch {
-        // noop
-      }
+    try {
+      await PsychicAppWebsockets.getOrFail().adapter().shutdown()
+    } catch {
+      // noop
     }
   }
 
@@ -137,35 +133,6 @@ export default class Cable {
         accept(true)
       })
     })
-  }
-
-  /**
-   * @internal
-   *
-   * establishes redis pubsub mechanisms
-   */
-  public bindToRedis() {
-    const config = PsychicAppWebsockets.getOrFail()
-    const pubClient = config.connection
-    const subClient = config.subConnection
-
-    if (!pubClient || !subClient) throw new MissingWsRedisConnection()
-
-    this.redisConnections.push(pubClient)
-    this.redisConnections.push(subClient)
-
-    pubClient.on('error', error => {
-      PsychicAppWebsockets.log('PUB CLIENT ERROR', error)
-    })
-    subClient.on('error', error => {
-      PsychicAppWebsockets.log('sub CLIENT ERROR', error)
-    })
-
-    try {
-      this.io!.adapter(createAdapter(pubClient, subClient))
-    } catch (error) {
-      PsychicAppWebsockets.log('FAILED TO ADAPT', error)
-    }
   }
 }
 

--- a/src/cable/redisWsKey.ts
+++ b/src/cable/redisWsKey.ts
@@ -1,3 +1,0 @@
-export default function redisWsKey(websocketId: string, redisKeyPrefix: string) {
-  return `${redisKeyPrefix}:${websocketId}:socket_ids`
-}

--- a/src/cable/ws.ts
+++ b/src/cable/ws.ts
@@ -1,28 +1,16 @@
-import { DateTime, Dream } from '@rvoh/dream'
-import { uniq } from '@rvoh/dream/utils'
-import { Emitter } from '@socket.io/redis-emitter'
+import { Dream } from '@rvoh/dream'
 import { Socket } from 'socket.io'
 import InvalidWsPathError from '../error/ws/InvalidWsPathError.js'
-import EnvInternal from '../helpers/EnvInternal.js'
 import PsychicAppWebsockets from '../psychic-app-websockets/index.js'
-import redisWsKey from './redisWsKey.js'
 
+/**
+ * Thin facade over the configured websockets adapter. `Ws` validates paths and
+ * builds the namespaced user key, then delegates registry + delivery to whichever
+ * {@link PsychicWebsocketsAdapter} is active for the environment (redis in
+ * production, in-process in test). The public surface — `new Ws(paths)`, `ws.emit`,
+ * `Ws.register`, `ws.findSocketIds` — is unchanged.
+ */
 export default class Ws<AllowedPaths extends readonly string[]> {
-  /**
-   * @internal
-   *
-   * the socket.io redis emitter instance, used to emit
-   * messages through redis to distributed websocket clusters
-   */
-  public io: Emitter
-
-  /**
-   * @internal
-   *
-   * the redis client used to bind socket.io to the redis emitter
-   */
-  private booted = false
-
   /**
    * @internal
    *
@@ -37,10 +25,9 @@ export default class Ws<AllowedPaths extends readonly string[]> {
    * when registering your application's users with psychic-websockets,
    * you need to provide the following:
    *   1. an identifier for your user (i.e. user.id)
-   *   2. a redisKeyPrefix, which is used to prefix your id before storing it in redis
+   *   2. a redisKeyPrefix, which is used to prefix your id before storing it
    *
-   * this enables you to have multiple namespaces in redis to safely store ids,
-   * i.e.
+   * this enables you to have multiple namespaces of ids, i.e.
    *
    *  `user:1`
    *  `admin-user:1`
@@ -55,29 +42,8 @@ export default class Ws<AllowedPaths extends readonly string[]> {
    * @param redisKeyPrefix - (optional) the prefix you wish to use to couple to this id (defaults to 'user')
    */
   public static async register(socket: Socket, id: string | number | Dream, redisKeyPrefix: string = 'user') {
-    const wsApp = PsychicAppWebsockets.getOrFail()
-    const redisClient = wsApp.connection
-    const websocketId = idOrDreamToId(id)
-    const redisKey = redisWsKey(websocketId, redisKeyPrefix)
-
-    const socketIdsToKeep = await redisClient.lrange(redisKey, -2, -1)
-
-    await redisClient
-      .multi()
-      .del(redisKey)
-      .rpush(redisKey, ...socketIdsToKeep, socket.id)
-      .expireat(
-        redisKey,
-        // TODO: make this configurable in non-test environments
-        DateTime.now()
-          .plus(EnvInternal.isTest ? { seconds: 15 } : { day: 1 })
-          .toSeconds(),
-      )
-      .exec()
-
-    socket.on('disconnect', async () => {
-      await redisClient.lrem(redisKey, 1, socket.id)
-    })
+    const adapter = PsychicAppWebsockets.getOrFail().adapter()
+    await adapter.register(wsUserKey(idOrDreamToId(id), redisKeyPrefix), socket)
   }
 
   constructor(
@@ -93,10 +59,9 @@ export default class Ws<AllowedPaths extends readonly string[]> {
        * when registering your application's users with psychic-websockets,
        * you need to provide the following:
        *   1. an identifier for your user (i.e. user.id)
-       *   2. a redisKeyPrefix, which is used to prefix your id before storing it in redis
+       *   2. a redisKeyPrefix, which is used to prefix your id before storing it
        *
-       * this enables you to have multiple namespaces in redis to safely store ids,
-       * i.e.
+       * this enables you to have multiple namespaces of ids, i.e.
        *
        *  `user:1`
        *  `admin-user:1`
@@ -109,20 +74,6 @@ export default class Ws<AllowedPaths extends readonly string[]> {
   ) {
     this.namespace = namespace
     this.redisKeyPrefix = redisKeyPrefix
-  }
-
-  /**
-   * @internal
-   *
-   * establishes a new socket.io-redis emitter
-   */
-  public boot() {
-    if (this.booted) return
-
-    const wsApp = PsychicAppWebsockets.getOrFail()
-
-    this.io = new Emitter(wsApp.connection).of(this.namespace)
-    this.booted = true
   }
 
   /**
@@ -141,37 +92,38 @@ export default class Ws<AllowedPaths extends readonly string[]> {
   ) {
     if (this.allowedPaths.length && !this.allowedPaths.includes(path)) throw new InvalidWsPathError(path)
 
-    this.boot()
-    const socketIds = await this.findSocketIds(idOrDreamToId(id))
-
-    for (const socketId of socketIds) {
-      this.io.to(socketId).emit(path, data)
-    }
+    const adapter = PsychicAppWebsockets.getOrFail().adapter()
+    await adapter.emit(this.namespace, this.userKey(idOrDreamToId(id)), path, data)
   }
 
   /**
    * @internal
    *
-   * used to find a redis key matching the id
+   * used to find the socket ids registered for the provided id
    */
   public async findSocketIds(userId: string): Promise<string[]> {
-    this.boot()
-
-    const wsApp = PsychicAppWebsockets.getOrFail()
-    return uniq(await wsApp.connection.lrange(this.redisKey(userId), 0, -1))
+    const adapter = PsychicAppWebsockets.getOrFail().adapter()
+    return adapter.socketIdsFor(this.userKey(userId))
   }
 
   /**
    * @internal
    *
-   * builds a redis key using the provided identifier and the redisKeyPrefix provided
-   * when this Ws instance was constructed.
+   * builds the namespaced user key from the provided identifier and the
+   * redisKeyPrefix provided when this Ws instance was constructed.
    */
-  private redisKey(userId: string) {
-    return redisWsKey(userId, this.redisKeyPrefix)
+  private userKey(userId: string) {
+    return wsUserKey(userId, this.redisKeyPrefix)
   }
 }
 
 function idOrDreamToId(id: string | number | Dream) {
   return id instanceof Dream ? (id.primaryKeyValue() as string).toString() : (id as string).toString()
+}
+
+/**
+ * the namespaced identity a socket is registered against, e.g. `user:123`.
+ */
+function wsUserKey(userId: string, redisKeyPrefix: string) {
+  return `${redisKeyPrefix}:${userId}`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { default as Cable } from './cable/index.js'
+export { default as InProcessWebsocketsAdapter } from './cable/adapter/InProcessWebsocketsAdapter.js'
+export { default as RedisWebsocketsAdapter } from './cable/adapter/RedisWebsocketsAdapter.js'
 export { default as Ws } from './cable/ws.js'
 export { default as PsychicAppWebsockets } from './psychic-app-websockets/index.js'
+
+export type { RecordedBroadcast } from './cable/adapter/InProcessWebsocketsAdapter.js'
+export type { PsychicWebsocketsAdapter } from './cable/adapter/PsychicWebsocketsAdapter.js'
+export type { WebsocketsAdapterSelector } from './cable/adapter/resolveWebsocketsAdapter.js'

--- a/src/psychic-app-websockets/index.ts
+++ b/src/psychic-app-websockets/index.ts
@@ -1,6 +1,10 @@
 import { PsychicApp } from '@rvoh/psychic'
 import { Cluster, Redis } from 'ioredis'
 import { Socket, Server as SocketServer, ServerOptions as SocketioServerOptions } from 'socket.io'
+import { PsychicWebsocketsAdapter } from '../cable/adapter/PsychicWebsocketsAdapter.js'
+import resolveWebsocketsAdapter, {
+  WebsocketsAdapterSelector,
+} from '../cable/adapter/resolveWebsocketsAdapter.js'
 import { cachePsychicAppWebsockets, getCachedPsychicAppWebsocketsOrFail } from './cache.js'
 
 export default class PsychicAppWebsockets {
@@ -50,6 +54,19 @@ export default class PsychicAppWebsockets {
   private _subConnection: RedisOrRedisClusterConnection
   public get subConnection() {
     return this._subConnection
+  }
+
+  private _adapterSelector: WebsocketsAdapterSelector | undefined
+  private _resolvedAdapter: PsychicWebsocketsAdapter | undefined
+
+  /**
+   * Returns the websockets adapter for this environment, resolving (and memoizing)
+   * the configured selector on first use. Defaults cable.yml-style: `test` →
+   * in-process, `development`/`production` → redis. Override with
+   * `wsApp.set('adapter', 'redis' | 'in_process' | <instance>)`.
+   */
+  public adapter(): PsychicWebsocketsAdapter {
+    return (this._resolvedAdapter ??= resolveWebsocketsAdapter(this._adapterSelector))
   }
 
   private _hooks: PsychicAppWebsocketsHooks = {
@@ -102,7 +119,9 @@ export default class PsychicAppWebsockets {
         ? Partial<SocketioServerOptions>
         : Opt extends 'healthCheck'
           ? Partial<HealthCheckOptions> | null
-          : never,
+          : Opt extends 'adapter'
+            ? WebsocketsAdapterSelector
+            : never,
   ) {
     switch (option) {
       case 'connection':
@@ -111,6 +130,11 @@ export default class PsychicAppWebsockets {
 
         this._connection = value as Redis
         this._subConnection = (value as Redis)?.duplicate()
+        break
+
+      case 'adapter':
+        this._adapterSelector = value as WebsocketsAdapterSelector
+        this._resolvedAdapter = undefined
         break
 
       case 'healthCheck':
@@ -134,7 +158,7 @@ export default class PsychicAppWebsockets {
   }
 }
 
-export type PsychicAppWebsocketsOption = 'connection' | 'socketio' | 'healthCheck'
+export type PsychicAppWebsocketsOption = 'connection' | 'socketio' | 'healthCheck' | 'adapter'
 
 interface HealthCheckOptions {
   path: string

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,94 @@
+import { isDeepStrictEqual } from 'node:util'
+import InProcessWebsocketsAdapter, { RecordedBroadcast } from '../cable/adapter/InProcessWebsocketsAdapter.js'
+import PsychicAppWebsockets from '../psychic-app-websockets/index.js'
+
+/**
+ * Spec helpers for asserting on websocket broadcasts. These read the in-process
+ * adapter's recorded-broadcast buffer, so they require the in-process adapter to be
+ * active (the default in the `test` environment). They sit alongside — and do not
+ * replace — the existing `vi.spyOn(AppWs, 'emit')` pattern, which keeps working.
+ *
+ * ```ts
+ * import { assertBroadcast, clearBroadcasts } from '@rvoh/psychic-websockets/testing'
+ *
+ * beforeEach(() => clearBroadcasts())
+ *
+ * it('notifies the user', async () => {
+ *   await subject()
+ *   assertBroadcast('/ops/howyadoin', { to: user.id, data: { hello: 'world' } })
+ * })
+ * ```
+ */
+
+export interface AssertBroadcastOptions {
+  /** the id the broadcast was emitted to (matched against the namespaced user key) */
+  to?: string | number
+  /** the redisKeyPrefix used when emitting; defaults to 'user' (matching `Ws`'s default) */
+  prefix?: string
+  /** the payload the broadcast carried; compared with deep strict equality */
+  data?: unknown
+}
+
+/**
+ * Returns the broadcasts recorded by the in-process adapter, in emit order,
+ * optionally filtered to a single path.
+ */
+export function websocketBroadcasts(path?: string): RecordedBroadcast[] {
+  const broadcasts = inProcessAdapterOrFail().broadcasts
+  return path === undefined ? [...broadcasts] : broadcasts.filter(broadcast => broadcast.path === path)
+}
+
+/**
+ * Clears the recorded-broadcast buffer. Call between examples (e.g. in `beforeEach`)
+ * so assertions only see broadcasts from the example under test.
+ */
+export function clearBroadcasts(): void {
+  inProcessAdapterOrFail().clearBroadcasts()
+}
+
+/**
+ * Asserts at least one recorded broadcast matches `path` (and the optional `to` /
+ * `data` constraints), throwing a descriptive error otherwise.
+ */
+export function assertBroadcast(path: string, options: AssertBroadcastOptions = {}): void {
+  const { to, prefix = 'user', data } = options
+  const expectedUserKey = to === undefined ? undefined : `${prefix}:${to.toString()}`
+
+  const matches = websocketBroadcasts(path).filter(broadcast => {
+    if (expectedUserKey !== undefined && broadcast.userKey !== expectedUserKey) return false
+    if (data !== undefined && !isDeepStrictEqual(broadcast.data, data)) return false
+    return true
+  })
+
+  if (matches.length === 0) {
+    const constraints: string[] = []
+    if (expectedUserKey !== undefined) constraints.push(`to "${expectedUserKey}"`)
+    if (data !== undefined) constraints.push(`with data ${JSON.stringify(data)}`)
+    const constraintText = constraints.length ? ` ${constraints.join(' ')}` : ''
+
+    throw new Error(
+      `Expected a websocket broadcast to "${path}"${constraintText}, but none was recorded.\n` +
+        `Recorded broadcasts: ${JSON.stringify(websocketBroadcasts(), null, 2)}`,
+    )
+  }
+}
+
+/**
+ * @internal
+ *
+ * resolves the active adapter, asserting it is the in-process adapter (the only one
+ * that records broadcasts).
+ */
+function inProcessAdapterOrFail(): InProcessWebsocketsAdapter {
+  const adapter = PsychicAppWebsockets.getOrFail().adapter()
+
+  if (!(adapter instanceof InProcessWebsocketsAdapter)) {
+    throw new Error(
+      'websocket broadcast test helpers require the in-process websockets adapter, but a ' +
+        `different adapter is active (${adapter.constructor.name}). Ensure the test environment ` +
+        "uses the in-process adapter (the default in `test`), e.g. wsApp.set('adapter', 'in_process').",
+    )
+  }
+
+  return adapter
+}

--- a/test-app/src/conf/websockets.ts
+++ b/test-app/src/conf/websockets.ts
@@ -7,17 +7,23 @@ import AppEnv from './AppEnv.js'
 export default (wsApp: PsychicAppWebsockets) => {
   if (AppEnv.serviceRole !== 'ws' && !AppEnv.isTest) return
 
-  wsApp.set(
-    'connection',
-    new Redis({
-      username: process.env.REDIS_USER,
-      password: process.env.REDIS_PASSWORD,
-      host: process.env.REDIS_HOST,
-      port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : undefined,
-      tls: process.env.REDIS_USE_SSL === '1' ? {} : undefined,
-      maxRetriesPerRequest: null,
-    }),
-  )
+  // Outside of test, the redis adapter (the default in development/production) needs
+  // a connection. In test, the default in-process adapter needs no redis: unit specs
+  // do zero redis I/O and feature specs still get real end-to-end delivery in-process
+  // via the attached socket.io server.
+  if (!AppEnv.isTest) {
+    wsApp.set(
+      'connection',
+      new Redis({
+        username: process.env.REDIS_USER,
+        password: process.env.REDIS_PASSWORD,
+        host: process.env.REDIS_HOST,
+        port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : undefined,
+        tls: process.env.REDIS_USE_SSL === '1' ? {} : undefined,
+        maxRetriesPerRequest: null,
+      }),
+    )
+  }
 
   wsApp.set('socketio', {
     // socketio server options here


### PR DESCRIPTION
## What

Replaces the hardcoded Redis websocket transport in `Ws`/`Cable` with a per-environment **adapter seam** modeled on Rails ActionCable's `cable.yml`. Part two of the spec-flakiness hardening effort (part one: spec server boots once per worker, psychic-spec-helpers#83).

## Why

In unit specs, app code that calls `AppWs.emit(...)` ran real Redis work (registry `LRANGE` + redis-emitter publish) for zero effect — no sockets are connected — which interfered with the test process and surfaced as intermittent `400`/`500`s (e.g. a `400` body of literally `"WebSockets request was expected"`). With the seam, the `test` environment uses an in-process adapter that does **no Redis I/O**, while production behavior is unchanged.

## Design

Two implementations of a `PsychicWebsocketsAdapter` interface cover all three Rails roles:

- **`RedisWebsocketsAdapter`** (production / development default) — prior behavior verbatim: registry in Redis, broadcasts via `@socket.io/redis-emitter`, installs the redis socket.io adapter on `attachServer`.
- **`InProcessWebsocketsAdapter`** (test default) — in-memory registry; **records every broadcast** for assertions; and **delivers in-process** via the attached socket.io server when one exists. Unit specs (no `attachServer`) record-only; feature specs (`Cable.start()` → `attachServer(io)`) record **and** deliver in-process to sockets on that server, no external Redis. Delivery is single-process: a cross-process emit (a web/worker process emitting to a socket held by the ws server) still needs the Redis adapter, as in production.

Selection (cable.yml-style), overridable via `wsApp.set('adapter', 'redis' | 'in_process' | <instance>)`:

| env | default |
|---|---|
| `test` | in-process |
| `development` | redis |
| `production` | redis |

`Ws` becomes a thin facade (validate path, build the namespaced user key, delegate). `Cable.start/stop` use `attachServer`/`shutdown` instead of `bindToRedis`, and no longer require a Redis connection when the in-process adapter is active.

New testing entrypoint `@rvoh/psychic-websockets/testing`: `websocketBroadcasts`, `assertBroadcast`, `clearBroadcasts`.

## Backward compatibility

Public API unchanged — `new Ws(paths)`, `ws.emit`, `Ws.register`, `wsApp.set('connection', …)`. Production with a connection and no explicit adapter resolves to Redis, identical to today. Only `test` flips to in-process by default (auto-fixing every app's unit suite on upgrade; opt back in with `set('adapter','redis')`).

## Validation

- `pnpm build` ✅ · `pnpm lint` ✅ · `pnpm uspec` ✅ (39 tests, stable across repeated runs)
- New `inProcessDelivery.spec.ts` boots a real `Cable` + `socket.io-client` and proves in-process delivery with zero Redis — the browser-free analogue of the puppeteer feature spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
