### PR TITLE
Bump patch version for GitHub npm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.0
+
+- switch to Github action publishing to npmjs.com
+
 ## 3.3.0
 
 - The two previously-hardcoded connection limits are now configurable on the websockets app:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.4.0
+## 3.3.1
 
 - switch to Github action publishing to npmjs.com
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-websockets",
   "description": "Websocket system for Psychic applications",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "author": "RVO Health",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-websockets",
   "description": "Websocket system for Psychic applications",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "author": "RVO Health",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumps the package minor version for GitHub releases and signed provenance while publishing to npmjs.com through GitHub Actions.