### PR TITLE
fix: upgrade to pnpm 11.9.0, deny build scripts in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.2
+
+- upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild/msgpackr-extract/puppeteer build scripts in pnpm-workspace.yaml
+
 ## 3.3.1
 
 - switch to Github action publishing to npmjs.com

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-websockets",
   "description": "Websocket system for Psychic applications",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "author": "RVO Health",
   "publishConfig": {
     "access": "public"
@@ -108,5 +108,5 @@
     "pluralize-esm": "^9.0.5",
     "yoctocolors": "^2.1.1"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,8 @@
 # the primary defense against Shai-Hulud-class npm worms. Only packages listed
 # below (= true) may run install/build scripts. Keep this MINIMAL — every entry
 # re-opens script execution for that package, so add one only with clear cause.
+strictDepBuilds: false
 allowBuilds:
-  esbuild: true
-  msgpackr-extract: true
-  puppeteer: true
+  esbuild: false
+  msgpackr-extract: false
+  puppeteer: false


### PR DESCRIPTION
## Summary

- Upgrades `packageManager` to `pnpm@11.9.0`
- Adds `strictDepBuilds: false` to `pnpm-workspace.yaml` to satisfy pnpm 11's hard-error on undeclared build-script deps
- Flips `esbuild`, `msgpackr-extract`, and `puppeteer` `allowBuilds` entries to `false` — esbuild and msgpackr-extract ship prebuilt binaries via optional deps so their postinstall is unnecessary; puppeteer's browser is installed via an explicit CI step
- Bumps package version to `3.3.2`

## Test plan

- [ ] `pnpm install` completes without `ERR_PNPM_IGNORED_BUILDS`
- [ ] CI passes (build, lint, unit specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY4PpeeQcHTxS2kZr1n8x